### PR TITLE
ui panel adjustments

### DIFF
--- a/src/components/ReportEditsChart.js
+++ b/src/components/ReportEditsChart.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {BarChart, Bar, CartesianGrid, XAxis, Tooltip} from 'recharts';
+import {ResponsiveContainer, BarChart, Bar, CartesianGrid, XAxis, Tooltip} from 'recharts';
 import {subMonths, format} from 'date-fns';
 import numeral from 'numeral';
 
@@ -22,7 +22,7 @@ const CustomTooltip = ({active, payload}) => {
     display: 'block',
     paddingTop: 4,
     paddingBottom: 4,
-    color: '#8884d8',
+    color: '#000',
   };
 
   if (active) {
@@ -66,12 +66,14 @@ export default class ReportsEditsChart extends Component {
     });
 
     return (
-      <BarChart height={300} width={600} data={data}>
-        <Tooltip isAnimationActive={false} content={<CustomTooltip/>}/>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="date" />
-        <Bar dataKey="edits" fill="#8884d8" fillOpacity={0.5} />
-      </BarChart>
+      <ResponsiveContainer width="100%" height={200}>
+        <BarChart data={data}>
+          <Tooltip isAnimationActive={false} cursor={{ fill: 'none', stroke: '#F3C983', strokeWidth: 1 }} content={<CustomTooltip/>}/>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="date" />
+          <Bar dataKey="edits" fill="#FFF" fillOpacity={0.9} />
+        </BarChart>
+      </ResponsiveContainer>
     )
   }
 }

--- a/src/graphics/icons/circle-information.svg
+++ b/src/graphics/icons/circle-information.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="1rem" height="1rem" viewBox="0 0 512 512" fill="#36414D" enable-background="new 0 0 512 512" xml:space="preserve">
+
+<path d="M224,384h64V224h-64V384z M256,128c-17.673,0-32,14.327-32,32s14.327,32,32,32c17.674,0,32-14.327,32-32
+	S273.674,128,256,128z M256,0C114.615,0,0,114.615,0,256c0,141.384,114.615,256,256,256c141.385,0,256-114.616,256-256
+	C512,114.615,397.385,0,256,0z M391.765,391.764C355.5,428.028,307.285,448,256,448s-99.5-19.972-135.765-56.236
+	C83.972,355.5,64,307.285,64,256s19.972-99.5,56.235-135.765C156.5,83.972,204.715,64,256,64s99.5,19.972,135.765,56.235
+	C428.028,156.5,448,204.715,448,256C448,307.284,428.028,355.5,391.765,391.764z"/>
+</svg>

--- a/src/styles/scss/global/_buttons.scss
+++ b/src/styles/scss/global/_buttons.scss
@@ -236,15 +236,30 @@
 }
 
 .button--info {
-  position: relative;
-  &:before {
-    content: url(../../graphics/icons/circle-information.svg);
+    padding-bottom: 0;
+    float: right;
+    margin-top: 0.35rem;
+  .info-text {
+    visibility: hidden;
+    background-color: #FFF;
+    color: $primary-color;
+    font-size: 0.75rem;
+    font-weight: $base-font-light;
+    font-style: italic;
     position: absolute;
-    height: 1rem;
-    margin-left: 0.25rem;
-    margin-top: 0.25rem;
-    left: 0;
-  }  
+    border-radius: $global-spacing/4;
+    z-index: 5;
+    padding: ($global-spacing/4) ($global-spacing/2);
+    margin-left: $global-spacing/4;
+    span {
+      width: 50%;
+      word-break: break-all;
+    }
+  } 
+}
+
+.button--info:hover .info-text {
+    visibility: visible;
 }
 
 /* ==========================================================================

--- a/src/styles/scss/global/_buttons.scss
+++ b/src/styles/scss/global/_buttons.scss
@@ -235,6 +235,18 @@
   }
 }
 
+.button--info {
+  position: relative;
+  &:before {
+    content: url(../../graphics/icons/circle-information.svg);
+    position: absolute;
+    height: 1rem;
+    margin-left: 0.25rem;
+    margin-top: 0.25rem;
+    left: 0;
+  }  
+}
+
 /* ==========================================================================
    Button groups
    ========================================================================== */

--- a/src/styles/scss/global/_charts.scss
+++ b/src/styles/scss/global/_charts.scss
@@ -1,0 +1,22 @@
+.recharts-wrapper {
+	width: 100% !important;
+}
+
+.recharts-cartesian-axis-tick text {
+  font-size: 0.75rem;
+  fill: #FFF;
+}
+
+.recharts-cartesian-grid {
+  opacity: 0;
+}
+
+.recharts-tooltip-wrapper {
+  visibility: visible !important;
+}
+
+.custom-tooltip-item {
+  span {
+    font-size: 0.875rem;
+  }
+}

--- a/src/styles/scss/index.scss
+++ b/src/styles/scss/index.scss
@@ -10,6 +10,7 @@
 @import "global/nav";
 @import "global/buttons";
 @import "global/forms";
+@import "global/charts";
 @import "home/global";
 @import "map/global";
 

--- a/src/styles/scss/map/_global.scss
+++ b/src/styles/scss/map/_global.scss
@@ -72,7 +72,7 @@
   @include column(6/12);
   top: 0;
   bottom: 0;
-  transition: left 0.75s ease-in-out;
+  transition: left 0.5s ease-in-out;
 }
 
 .report__panel-container--closed {
@@ -94,18 +94,11 @@
 
 .report__panel {
   color: #FFF;
-  position: relative;
   height: 90vh;
   width: 95%;
   float: left;
   background: linear-gradient(to bottom, rgba(52,71,98,0.8) 0%,rgba(38,35,35,0.8) 100%);
   overflow: auto;
-  .inner {
-    position: relative;
-    overflow: scroll;
-    -ms-overflow-style: none;
-    overflow: -moz-scrollbars-none;
-  }
   .inner::-webkit-scrollbar { 
     display: none; 
   }

--- a/src/styles/scss/map/_global.scss
+++ b/src/styles/scss/map/_global.scss
@@ -72,6 +72,14 @@
   @include column(6/12);
   top: 0;
   bottom: 0;
+  transition: left 0.75s ease-in-out;
+}
+
+.report__panel-container--closed {
+  left: -46%;
+}
+
+.report__panel-container--open {
   left: 0;
 }
 
@@ -117,6 +125,7 @@
   }
   button {
     float: right;
+    display: none;
   }
 }
 
@@ -153,6 +162,9 @@
 .report__section {
   @extend .clearfix;
   margin: $global-spacing 0;
+  &:last-child {
+    margin-bottom: 4rem;
+  }
 }
 
 .report__section-header {
@@ -170,14 +182,20 @@
 
 .report__section-body {
   margin-top: $global-spacing;
-  float: left;
+  position: relative;
   .stat-list {
     li {
       @include column(4/12);
     }
   }
   p {
+    font-size: 1.15rem;
     margin-bottom: $global-spacing;
+    small {
+      opacity: 0.7;
+      font-weight: 300;
+      margin-left: $global-spacing/2;
+    }
   }
 }
 
@@ -193,6 +211,10 @@
     font-weight: $base-font-bold;
     font-size: 0.75rem;
     text-transform: uppercase;
+    float: left;
+  }
+  button {
+    float: right;
   }
 }
 

--- a/src/views/Report.js
+++ b/src/views/Report.js
@@ -7,6 +7,7 @@ import {requestBoundary} from '../state/ReportState';
 import numeral from 'numeral';
 import {format} from 'date-fns';
 import upperFirst from 'lodash.upperfirst';
+import infoIcon from '../graphics/icons/circle-information.svg';
 
 class Report extends Component {
   constructor (props) {
@@ -73,7 +74,11 @@ class Report extends Component {
             <div className='report__status report__status--good'>
               <div className='inner'>
                 <p> AOI Relative Completeness: Good </p>
-                <button className='button button--info'></button>
+                <button className='button button--info'>
+                <img src={infoIcon}/>
+                  <div className="info-text"><span>OSM coverage is great, better than population density would imply
+</span></div>
+                </button>
               </div>
             </div>
             <div className='inner'>

--- a/src/views/Report.js
+++ b/src/views/Report.js
@@ -129,7 +129,7 @@ class Report extends Component {
             </div>
           </div>
           <div className='report__panel-button' >
-            <button className='button button--slide-close' onClick={this.togglePanel} />
+            <button className={`button ${this.state.panelOpen? 'button--slide-close':'button--slide-open'}`} onClick={this.togglePanel} />
           </div>
           </div>
         </div>

--- a/src/views/Report.js
+++ b/src/views/Report.js
@@ -61,7 +61,8 @@ class Report extends Component {
             <div className='report__panel'>
             <div className='report__status report__status--good'>
               <div className='inner'>
-                <p> AOI OSM Data Status: Good </p>
+                <p> AOI Relative Completeness: Good </p>
+                <button className='button button--info'></button>
               </div>
             </div>
             <div className='inner'>
@@ -79,15 +80,10 @@ class Report extends Component {
               <div className='report__body'>
                 <div className='report__section'>
                   <div className='report__section-header'>
-                    <h2 className='report__section-title'>Relative Completeness</h2>
-                  </div>
-                </div>
-                <div className='report__section'>
-                  <div className='report__section-header'>
                     <h2 className='report__section-title'>Attribute Completeness</h2>
                   </div>
                   <div className='report__section-body'>
-                    <p><strong>{numberBuildings.format('0,0')} </strong><small>OSM buildings in this AOI</small></p>
+                    <p>{numberBuildings.format('0,0')}<small>OSM buildings in this AOI</small></p>
                     <ul className='stat-list'>
                       <li>{numberUntaggedWays.format('0,0')}<small>untagged closeways</small></li>
                       <li>{percentResidentialBuildings.format('0%')}<small>residential buildings</small></li>
@@ -98,6 +94,8 @@ class Report extends Component {
                 <div className='report__section'>
                   <div className='report__section-header'>
                     <h2 className='report__section-title'>Temporal Accuracy</h2>
+                  </div>
+                  <div className='report__section-body'>
                     <ReportEditsChart timeBins={timeBins} />
                   </div>
                 </div>

--- a/src/views/Report.js
+++ b/src/views/Report.js
@@ -75,7 +75,7 @@ class Report extends Component {
               <div className='inner'>
                 <p> AOI Relative Completeness: Good </p>
                 <button className='button button--info'>
-                <img src={infoIcon}/>
+                <img alt='information' src={infoIcon}/>
                   <div className="info-text"><span>OSM coverage is great, better than population density would imply
 </span></div>
                 </button>


### PR DESCRIPTION
@kamicut this PR
- styles bar chart
- removes relative completeness section in favor of using bar up top
- adds an info button to relative completeness
- small type updates
- adds classes for sliding panel

To Do:
- add tooltip to info button on hover
- add .report__panel-container--open or  .report__panel-container--closed to .report__panel--container when sliding button is clicked
- add y axis to chart