### PR TITLE
use index for completeness

### DIFF
--- a/src/components/CompletenessStatus.js
+++ b/src/components/CompletenessStatus.js
@@ -20,6 +20,7 @@ const labels = {
 }
 
 export default ({ completenessPercentage }) => {
+  console.log(completenessPercentage);
   let status = 'good';
   if (completenessPercentage < 0.5) {
     status = 'fair';

--- a/src/views/Report.js
+++ b/src/views/Report.js
@@ -40,7 +40,8 @@ class Report extends Component {
       totalBuildings,
       untaggedWays,
       population,
-      completenessPercentage
+      completenessPercentage,
+      averageCompleteness
     } = stats['building-stats'];
 
     const timestamp = stats.timestamp;
@@ -62,7 +63,7 @@ class Report extends Component {
           {<ReportMap aoi={layer} domain={domain} />}
           <PanelContainer>
             <div className='report__panel'>
-              <CompletenessStatus completenessPercentage={completenessPercentage} />
+              <CompletenessStatus completenessPercentage={averageCompleteness} />
 
               <div className='inner'>
                 <div className='report__actions'>


### PR DESCRIPTION
@kamicut @ascalamogna @echeipesh - I switched to the index now [that it's adjusted](https://github.com/hotosm/osma-health/issues/68). Let me know what you think? 

It still uses the scale of `-0.5, 0, 0.5`

This looks pretty good to me. 

![image](https://user-images.githubusercontent.com/371666/39311960-ebe8f8b4-498b-11e8-8264-bfdb796762d1.png)
_chobe_


![image](https://user-images.githubusercontent.com/371666/39312007-08d6f25a-498c-11e8-95ac-0a0de83dba13.png)
_nata_ 